### PR TITLE
turn-on-data now uses ip instead of nmcli

### DIFF
--- a/shell/nodes.sh
+++ b/shell/nodes.sh
@@ -276,7 +276,7 @@ function turn-on-data() {
             ip link show $ifname | grep -q UP || {
                 echo "turn-on-data: data network on interface" $ifname >&2-
                 # this should work except on fedora-33; go figure
-                ifup $ifname >&2- || nmcli connection up $ifname
+                ifup $ifname >&2- || ip link set $ifname up
             }
             echo $ifname
             break


### PR DESCRIPTION
For some reason, nmcli is unable to work inside a Docker container, even with full capabilities enabled.
I think it is because it is still missing some daemons.

Using `ip` works and basically does the same thing, so we should be good.