### PR TITLE
Pointing ~/.bash_profile and /etc/profile.d/nodes.sh to nodes.sh

### DIFF
--- a/docker-images/baleine/Dockerfile
+++ b/docker-images/baleine/Dockerfile
@@ -17,7 +17,6 @@ RUN ln -s /root/r2lab-embedded/shell/nodes.sh /root/.bashrc
 
 RUN ln -s /root/r2lab-embedded/shell/nodes.sh /etc/profile.d/nodes.sh
 
-RUN rm /root/.bash_profile
 RUN ln -s /root/r2lab-embedded/shell/nodes.sh /root/.bash_profile
 
 # Setup Bash prompt to not get lost when in interactive mode

--- a/docker-images/baleine/Dockerfile
+++ b/docker-images/baleine/Dockerfile
@@ -15,5 +15,10 @@ RUN git clone https://github.com/fit-r2lab/r2lab-embedded.git /root/r2lab-embedd
 RUN rm /root/.bashrc
 RUN ln -s /root/r2lab-embedded/shell/nodes.sh /root/.bashrc
 
+RUN ln -s /root/r2lab-embedded/shell/nodes.sh /etc/profile.d/nodes.sh
+
+RUN rm /root/.bash_profile
+RUN ln -s /root/r2lab-embedded/shell/nodes.sh /root/.bash_profile
+
 # Setup Bash prompt to not get lost when in interactive mode
 RUN echo "PS1='[CONTAINER]${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '" | tee -a /root/.bashrc > /dev/null

--- a/docker-images/baleine/Dockerfile
+++ b/docker-images/baleine/Dockerfile
@@ -1,5 +1,28 @@
 FROM ubuntu:latest
 
+# Install necessary binaries for tutorials
+RUN apt update -y && apt upgrade -y && apt install kmod iw iputils-ping openssh-client openssh-server bash netcat iproute2 net-tools tcpdump dnsutils netcat nano vim -y
+
+# Setup Bash prompt to not get lost when in interactive mode
+RUN echo "PS1='[CONTAINER] ${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '" | tee /root/.bashrc > /dev/null
+
+#Setting up OpenSSH server
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
+RUN sed -i 's/#Port 22/Port 2222/g' /etc/ssh/sshd_config
+RUN sed -i 's/#ListenAddress 0.0.0.0/ListenAddress 0.0.0.0/g' /etc/ssh/sshd_config
+RUN echo "auth sufficient pam_permit.so" | tee -a /etc/pam.d/sshd >> /dev/null
+
+RUN mkdir -p /run/sshd
+RUN echo "PermitEmptyPasswords yes" | tee -a /etc/ssh/sshd_config >> /dev/null
+RUN passwd -d root
+
+RUN mkdir /root/.ssh
+
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
 ENV TZ=Europe/Paris
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -19,5 +42,6 @@ RUN ln -s /root/r2lab-embedded/shell/nodes.sh /etc/profile.d/nodes.sh
 
 RUN ln -s /root/r2lab-embedded/shell/nodes.sh /root/.bash_profile
 
-# Setup Bash prompt to not get lost when in interactive mode
-RUN echo "PS1='[CONTAINER]${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '" | tee -a /root/.bashrc > /dev/null
+EXPOSE 2222
+
+CMD ["/usr/sbin/sshd", "-D"]


### PR DESCRIPTION
This allows us to run Bash functions such as `turn-on-data` without having to enter an interactive Bash session.